### PR TITLE
workaround avcodec_find_encoder_by_name() unreliably indicating that h264_omx codec is available

### DIFF
--- a/h264_encoder_core/CMakeLists.txt
+++ b/h264_encoder_core/CMakeLists.txt
@@ -8,17 +8,6 @@ add_compile_options(-std=c++11)
 find_package(aws_common REQUIRED)
 
 
-# determine if OMX hardware encoder is available
-find_library(OPENMAXIL openmaxil /opt/vc/lib)
-find_library(BCM_HOST bcm_host /opt/vc/lib)
-find_library(OMXCORE NAMES OMX_Core OMXCore)
-
-if((OPENMAXIL AND BCM_HOST) OR OMXCORE)
-  message("Hardware encoder detected")
-  add_definitions(-DHARDWARE_ENCODER)
-endif()
-
-
 #############
 ## Compile ##
 #############
@@ -38,6 +27,7 @@ target_link_libraries(${PROJECT_NAME}
   avcodec
   avutil
   swscale
+  dl
 )
 
 

--- a/h264_encoder_core/CMakeLists.txt
+++ b/h264_encoder_core/CMakeLists.txt
@@ -8,6 +8,17 @@ add_compile_options(-std=c++11)
 find_package(aws_common REQUIRED)
 
 
+# determine if OMX hardware encoder is available
+find_library(OPENMAXIL openmaxil /opt/vc/lib)
+find_library(BCM_HOST bcm_host /opt/vc/lib)
+find_library(OMXCORE NAMES OMX_Core OMXCore)
+
+if((OPENMAXIL AND BCM_HOST) OR OMXCORE)
+  message("Hardware encoder detected")
+  add_definitions(-DHARDWARE_ENCODER)
+endif()
+
+
 #############
 ## Compile ##
 #############

--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -42,8 +42,8 @@ constexpr char kFpsDenominatorKey[] = "fps_denominator";
 constexpr char kCodecKey[] = "codec";
 constexpr char kBitrateKey[] = "bitrate";
 
-constexpr char kPrimaryDefaultCodec[] = "h264_omx";
-constexpr char kSecondaryDefaultCodec[] = "libx264";
+constexpr char kDefaultHardwareCodec[] = "h264_omx";
+constexpr char kDefaultSoftwareCodec[] = "libx264";
 constexpr float kFragmentDuration = 1.0f; /* set fragment duration to 1.0 second */
 constexpr int kDefaultMaxBFrames = 0;
 constexpr int kDefaultFpsNumerator = 24;
@@ -125,15 +125,17 @@ public:
     avcodec_register_all();
 
     /* find the mpeg1 video encoder */
-    AVCodec * codec;
+    AVCodec * codec = nullptr;
     AVDictionary * opts = nullptr;
     if (codec_name.empty()) {
-      codec = avcodec_find_encoder_by_name(kPrimaryDefaultCodec);
+#ifdef HARDWARE_ENCODER
+      codec = avcodec_find_encoder_by_name(kDefaultHardwareCodec);
+#endif
       if (nullptr == codec) {
-        codec = avcodec_find_encoder_by_name(kSecondaryDefaultCodec);
+        codec = avcodec_find_encoder_by_name(kDefaultSoftwareCodec);
         if (nullptr == codec) {
-          AWS_LOGSTREAM_ERROR(__func__, kPrimaryDefaultCodec << " and " << kSecondaryDefaultCodec
-                                                             << " codecs were not found!");
+          AWS_LOGSTREAM_ERROR(__func__, kDefaultHardwareCodec << " and " << kDefaultSoftwareCodec
+                                                              << " codecs were not available!");
           return AWS_ERR_NOT_FOUND;
         }
         av_dict_set(&opts, "preset", "veryfast", 0);

--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -21,6 +21,7 @@
 #include <h264_encoder_core/h264_encoder.h>
 
 #include <cstdio>
+#include <dlfcn.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -30,6 +31,41 @@ extern "C" {
 }
 
 using namespace Aws::Utils::Logging;
+
+
+static bool is_omx_available()
+{
+  constexpr static const char * lib_names[3][2] = {
+    { "/opt/vc/lib/libopenmaxil.so", "/opt/vc/lib/libbcm_host.so" },
+    { "libOMX_Core.so", nullptr },
+    { "libOmxCore.so", nullptr }
+  };
+  constexpr static int num_libs = sizeof(lib_names) / sizeof(lib_names[0]);
+
+  for (int i = 0; i < num_libs; ++i) {
+    if (nullptr != lib_names[i][1]) {
+      void * lib2_handle = dlopen(lib_names[i][1], RTLD_NOW | RTLD_GLOBAL);
+      if (nullptr == lib2_handle) {
+        continue;
+      }
+
+      void * lib2_func = dlsym(lib2_handle, "bcm_host_init");
+      dlclose(lib2_handle);
+      if (nullptr == lib2_func) {
+        continue;
+      }
+    }
+
+    void * lib1_handle = dlopen(lib_names[i][0], RTLD_NOW | RTLD_GLOBAL);
+    if (nullptr != lib1_handle) {
+      dlclose(lib1_handle);
+      return true;
+    }
+  }
+
+  return false;
+}
+
 
 namespace Aws {
 namespace Utils {
@@ -128,10 +164,8 @@ public:
     AVCodec * codec = nullptr;
     AVDictionary * opts = nullptr;
     if (codec_name.empty()) {
-#ifdef HARDWARE_ENCODER
       codec = avcodec_find_encoder_by_name(kDefaultHardwareCodec);
-#endif
-      if (nullptr == codec) {
+      if (nullptr == codec || !is_omx_available()) {
         codec = avcodec_find_encoder_by_name(kDefaultSoftwareCodec);
         if (nullptr == codec) {
           AWS_LOGSTREAM_ERROR(__func__, kDefaultHardwareCodec << " and " << kDefaultSoftwareCodec


### PR DESCRIPTION
*Issue #2*

*Description of changes:*

On Ubuntu Bionic 18.04 x64, libavcodec.so's `avcodec_find_encoder_by_name()` indicates that the "h264_omx" codec is available, but the codec depends on libOMX_Core.so/libOMXCore.so, which are not available and means that the "h264_omx" codec simply does not work.

The fix is to have CMake detect the presence of libOMX_Core.so/libOMXCore.so (or libopenmaxil.so and libbcm_host.so in the case of Raspberry Pi's, see https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/omx.c#L142) on the system to decide whether or not the hardware encoder should be used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
