### PR TITLE
fix h264_encoder_test to be compatible with new ParameterReader API

### DIFF
--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/aws-robotics/utils-common.git
+    local-name: utils-common
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,16 @@ notifications:
       - ros-contributions@amazon.com
       - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
+  global:
+    - UPSTREAM_WORKSPACE=file
+    - ROSINSTALL_FILENAME=.rosinstall.master
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:


### PR DESCRIPTION
*Description of changes:*

With the update to the ParameterReader API to use the new ParameterPath class, the h264_encoder_test needs to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
