### PR TITLE
Restrict aws robotics dependencies

### DIFF
--- a/h264_encoder_core/package.xml
+++ b/h264_encoder_core/package.xml
@@ -12,12 +12,12 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>aws_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_common</build_depend>
   <build_depend>ffmpeg</build_depend>
   
-  <build_export_depend>aws_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>aws_common</build_export_depend>
 
-  <exec_depend>aws_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>aws_common</exec_depend>
   <exec_depend>ffmpeg</exec_depend>
   
   <export>


### PR DESCRIPTION
Set aws-robotics dependencies to less than 2.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
