### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+using namespace Aws::Client;
 using namespace Aws::Utils::Logging;
 
 
@@ -330,19 +331,19 @@ H264Encoder::~H264Encoder() {}
 
 AwsError H264Encoder::Initialize(const int src_width, const int src_height,
                                  const AVPixelFormat src_encoding,
-                                 const Aws::Client::ParameterReaderInterface & dst_params)
+                                 const ParameterReaderInterface & dst_params)
 {
   int dst_width, dst_height;
-  bool dims_set = (dst_params.ReadInt(kOutputWidthKey, dst_width) == Aws::AWS_ERR_OK &&
-                   dst_params.ReadInt(kOutputHeightKey, dst_height) == Aws::AWS_ERR_OK);
+  bool dims_set = (dst_params.ReadParam(ParameterPath(kOutputWidthKey), dst_width) == Aws::AWS_ERR_OK &&
+                   dst_params.ReadParam(ParameterPath(kOutputHeightKey), dst_height) == Aws::AWS_ERR_OK);
   if (!dims_set) {
     dst_width = src_width;
     dst_height = src_height;
   }
 
   int fps_num, fps_den;
-  bool fps_set = (dst_params.ReadInt(kFpsNumeratorKey, fps_num) == Aws::AWS_ERR_OK &&
-                  dst_params.ReadInt(kFpsDenominatorKey, fps_den) == Aws::AWS_ERR_OK);
+  bool fps_set = (dst_params.ReadParam(ParameterPath(kFpsNumeratorKey), fps_num) == Aws::AWS_ERR_OK &&
+                  dst_params.ReadParam(ParameterPath(kFpsDenominatorKey), fps_den) == Aws::AWS_ERR_OK);
   if (!fps_set) {
     AWS_LOG_WARN(__func__, "fps not set");
     fps_num = kDefaultFpsNumerator;
@@ -350,10 +351,10 @@ AwsError H264Encoder::Initialize(const int src_width, const int src_height,
   }
 
   std::string codec;
-  dst_params.ReadStdString(kCodecKey, codec);
+  dst_params.ReadParam(ParameterPath(kCodecKey), codec);
 
   int bitrate = kDefaultBitrate;
-  dst_params.ReadInt(kBitrateKey, bitrate);
+  dst_params.ReadParam(ParameterPath(kBitrateKey), bitrate);
 
   impl_ = std::unique_ptr<H264EncoderImpl>(new H264EncoderImpl());
 

--- a/h264_encoder_core/src/h264_encoder_node_config.cpp
+++ b/h264_encoder_core/src/h264_encoder_node_config.cpp
@@ -37,16 +37,16 @@ Aws::AwsError GetH264EncoderNodeParams(const Aws::Client::ParameterReaderInterfa
                                        H264EncoderNodeParams & params)
 {
   params.subscription_topic = kDefaultSubscriptionTopic;
-  param_reader.ReadStdString(kSubscriptionTopicKey, params.subscription_topic);
+  param_reader.ReadParam(Aws::Client::ParameterPath(kSubscriptionTopicKey), params.subscription_topic);
 
   params.metadata_topic = kDefaultMetadataTopic;
-  param_reader.ReadStdString(kMetadataTopicKey, params.metadata_topic);
+  param_reader.ReadParam(Aws::Client::ParameterPath(kMetadataTopicKey), params.metadata_topic);
 
   params.publication_topic = kDefaultPublicationTopic;
-  param_reader.ReadStdString(kPublicationTopicKey, params.publication_topic);
+  param_reader.ReadParam(Aws::Client::ParameterPath(kPublicationTopicKey), params.publication_topic);
 
   params.queue_size = kDefaultQueueSize;
-  param_reader.ReadInt(kQueueSizeKey, params.queue_size);
+  param_reader.ReadParam(Aws::Client::ParameterPath(kQueueSizeKey), params.queue_size);
   if (params.queue_size < 0) {
     AWS_LOGSTREAM_ERROR(__func__, "Invalid queue size " << params.queue_size << "!");
     return AWS_ERR_PARAM;

--- a/h264_encoder_core/test/h264_encoder_test.cpp
+++ b/h264_encoder_core/test/h264_encoder_test.cpp
@@ -37,12 +37,13 @@ constexpr int kDefaultBitrate = 2048000;
 constexpr char kDefaultCodec[] = "libx264";
 
 using namespace Aws;
+using namespace Aws::Client;
 using namespace Aws::Utils::Encoding;
 
 /**
  * Parameter reader that sets the output using provided std::mapS.
  */
-class TestParameterReader : public Client::ParameterReaderInterface
+class TestParameterReader : public ParameterReaderInterface
 {
 public:
   TestParameterReader() {}
@@ -58,9 +59,10 @@ public:
     string_map_ = {{"codec", codec}};
   }
 
-  AwsError ReadInt(const char * name, int & out) const
+  AwsError ReadParam(const ParameterPath & param_path, int & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (int_map_.count(name) > 0) {
       out = int_map_.at(name);
       result = AWS_ERR_OK;
@@ -68,14 +70,15 @@ public:
     return result;
   }
 
-  AwsError ReadBool(const char * name, bool & out) const
+  AwsError ReadParam(const ParameterPath & param_path, bool & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadStdString(const char * name, std::string & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::string & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (string_map_.count(name) > 0) {
       out = string_map_.at(name);
       result = AWS_ERR_OK;
@@ -83,9 +86,10 @@ public:
     return result;
   }
 
-  AwsError ReadString(const char * name, Aws::String & out) const
+  AwsError ReadParam(const ParameterPath & param_path, Aws::String & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (string_map_.count(name) > 0) {
       out = string_map_.at(name).c_str();
       result = AWS_ERR_OK;
@@ -93,22 +97,22 @@ public:
     return result;
   }
 
-  AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadList(const char * name, std::vector<std::string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadDouble(const char * name, double & out) const {
+  AwsError ReadParam(const ParameterPath & param_path, double & out) const {
     return AWS_ERR_NOT_FOUND;
   }
 
 private:
-  std::string FormatParameterPath(const Client::ParameterPath & param_path) const
+  std::string FormatParameterPath(const ParameterPath & param_path) const
   {
     return param_path.get_resolved_path('/', '/');
   }


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
