### PR TITLE
Link libraries only if test target exists

### DIFF
--- a/h264_encoder_core/CMakeLists.txt
+++ b/h264_encoder_core/CMakeLists.txt
@@ -72,13 +72,15 @@ find_common_test_packages()
 add_common_gtest(test_h264_encoder_core
   test/h264_encoder_test.cpp
 )
-target_include_directories(test_h264_encoder_core PRIVATE
-  include
-  ${aws_common_INCLUDE_DIRS}
-)
-target_link_libraries(test_h264_encoder_core
-  ${PROJECT_NAME}
-  ${aws_common_LIBRARIES}
-  ${GMOCK_LIBRARY}
-  pthread
-)
+if(TARGET test_h264_encoder_core)
+  target_include_directories(test_h264_encoder_core PRIVATE
+    include
+    ${aws_common_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_h264_encoder_core
+    ${PROJECT_NAME}
+    ${aws_common_LIBRARIES}
+    ${GMOCK_LIBRARY}
+    pthread
+  )
+endif()

--- a/h264_encoder_core/package.xml
+++ b/h264_encoder_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>h264_encoder_core</name>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <description>Common base code for ROS1/ROS2 H264 encoder node</description>
   <url>http://wiki.ros.org/h264_encoder_core</url>
 


### PR DESCRIPTION
Checking if the target exists before using it (like we did in cloudwatch-common).

ROS1Prerelease: https://travis-ci.org/AAlon/ROS1Prerelease/builds/582200175
ROS2Prerelease: https://travis-ci.org/AAlon/ROS2Prerelease/builds/582200215 (Pretty sure it passed. there might be a bug in ros-industrial that caused the last step - `colcon test-result` - to fail)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
