### PR TITLE
Backoff to software encoding if codec isn't available

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ The source code is released under [LGPL 2.1]. However, h264_encoder_core incorpo
 * ROS build farm:
     * ROS Kinetic @ u16.04 Xenial [![Build Status](http://build.ros.org/job/Kbin_uX64__h264_encoder_core__ubuntu_xenial_amd64__binary/badge/icon)](http://build.ros.org/job/Kbin_uX64__h264_encoder_core__ubuntu_xenial_amd64__binary)
     * ROS Melodic @ u18.04 Bionic [![Build Status](http://build.ros.org/job/Mbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary/)
-   * ROS Dashing @ u18.04 Bionic [![Build Status](http://build.ros2.org/job/Dbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros2.org/job/Dbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary)
+    * ROS Dashing @ u18.04 Bionic [![Build Status](http://build.ros2.org/job/Dbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros2.org/job/Dbin_uB64__h264_encoder_core__ubuntu_bionic_amd64__binary)
 
 ## Installation
+
+**Installing on Raspberry Pi**
+
+It is recommended that you build this package from source for use on the Raspberry Pi. The ROS2 build farm doesn't have ffmpeg and related encoding libraries that are specific to the Raspberry Pi and required to enable hardware encoding. If installing from apt on RaspberryPi expect to use software encoding which can be very slow with limited computing resources. Raspberry Pi-compatible ffmpeg binaries can be found in the ppa:ubuntu-pi-flavour-makers/ppa repository . Once you add the PPA to your system and use rosdep install to fetch the dependencies, you will be able to build this package and link it against the compatible dependencies.
 
 ### Binaries
 On Ubuntu you can install the latest version of this package using the following command

--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -67,6 +67,19 @@ static bool is_omx_available()
   return false;
 }
 
+static bool is_codec_available(AVCodec * codec) {
+  AVCodecContext * param = avcodec_alloc_context3(codec);
+  AVDictionary * opts = nullptr;
+
+  bool open_result = avcodec_open2(param, codec, &opts) < 0;
+  if (nullptr != param) {
+    avcodec_close(param);
+    av_free(param);
+  }
+ 
+  return open_result;
+}
+
 
 namespace Aws {
 namespace Utils {
@@ -166,7 +179,7 @@ public:
     AVDictionary * opts = nullptr;
     if (codec_name.empty()) {
       codec = avcodec_find_encoder_by_name(kDefaultHardwareCodec);
-      if (nullptr == codec || !is_omx_available()) {
+      if (nullptr == codec || !is_omx_available() || !is_codec_available(codec)) {
         codec = avcodec_find_encoder_by_name(kDefaultSoftwareCodec);
         if (nullptr == codec) {
           AWS_LOGSTREAM_ERROR(__func__, kDefaultHardwareCodec << " and " << kDefaultSoftwareCodec

--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -38,7 +38,7 @@ static bool is_codec_available(AVCodec * codec) {
   AVCodecContext * param = avcodec_alloc_context3(codec);
   AVDictionary * opts = nullptr;
 
-  bool open_result = avcodec_open2(param, codec, &opts) < 0;
+  bool open_result = avcodec_open2(param, codec, &opts) >= 0;
   if (nullptr != param) {
     avcodec_close(param);
     av_free(param);


### PR DESCRIPTION
Signed-off-by: Ryan Newell <ryanewel@amazon.com>

*Issue #, if available:*
Related to https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/2 and implements suggestion 1 from https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/23
*Description of changes:*
Tries to open the hardware codec before deciding if it's available.

This change was manually tested on a raspberry Pi 3B+ running Ubuntu Mate 18.04 armhf.

Tested the following cases:
1. Specified a valid codec (hevc_amf) that wasn't installed on the raspberry Pi. It correctly switched to software encoding
2. Specified a valid codec that was on the raspberry Pi, but ffmpeg was incorrectly configured so that it couldn't be used. The node correctly switched to software encoding
3. Specified a valid codec that was on the raspberry Pi and ffmpeg was configured to use. The node correctly used hardware encoding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
