### PR TITLE
Update codec opening test to include opts and params

### DIFF
--- a/h264_encoder_core/package.xml
+++ b/h264_encoder_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>h264_encoder_core</name>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
   <description>Common base code for ROS1/ROS2 H264 encoder node</description>
   <url>http://wiki.ros.org/h264_encoder_core</url>
 

--- a/h264_encoder_core/src/h264_encoder.cpp
+++ b/h264_encoder_core/src/h264_encoder.cpp
@@ -113,13 +113,8 @@ public:
     }
 
     AWS_LOGSTREAM_INFO(__func__, "Attempting to open codec: " << codec->name);
-    /*
-    if () {
-      AWS_LOG_ERROR(__func__, "Failed to set context for codec, could not open codec.");
-      return AWS_ERR_FAILURE;
-    }*/
 
-    if (AWS_ERR_OK != set_param(codec) || avcodec_open2(param_, codec, &opts) < 0 ) { //|| std::strcmp("h264_omx", codec->name)==0) {
+    if (AWS_ERR_OK != set_param(codec) || avcodec_open2(param_, codec, &opts) < 0 ) {
       AWS_LOG_ERROR(__func__, "Could not open codec");
       if (nullptr != param_) {
 	      avcodec_close(param_);


### PR DESCRIPTION
Signed-off-by: Ryan Newell <ryanewel@amazon.com>

*Issue #, if available:* https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/36

*Description of changes:*
Rearrange the codec opening logic so that parameters are included
Unit tests passed
Tested following cases manually

*Running with hardware encoding enabled*
Node correctly uses hardware encoding
Saw video in Kinesis console
```
$ ros2 run h264_video_encoder h264_video_encoder __params:=video_encoder_config.yaml
[INFO] [h264_video_encoder]: [RunEncoderNode] Starting H264 Video Node...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /videofile/image_raw...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /image_metadata for metadata...
[INFO] [h264_video_encoder]: [open_codec] Attempting to open codec: h264_omx
[h264_omx @ 0x240cb70] Using OMX.broadcom.video_encode
[INFO] [h264_video_encoder]: [Initialize] Encoding using h264_omx codec
```

*Running with an unavailable codec specified in config*
Node then exited as intended
```
$ ros2 run h264_video_encoder h264_video_encoder __params:=video_encoder_config.yaml
[INFO] [h264_video_encoder]: [RunEncoderNode] Starting H264 Video Node...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /videofile/image_raw...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /image_metadata for metadata...
[ERROR] [h264_video_encoder]: [Initialize] hevc_amf codec not found!
```

*Running node with broken hardware encoding*
Node successfully backs off to software encoding,
Saw video in kinesis console
```
ros2 run h264_video_encoder h264_video_encoder __params:=video_encoder_config.yaml
[INFO] [h264_video_encoder]: [RunEncoderNode] Starting H264 Video Node...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /videofile/image_raw...
[INFO] [h264_video_encoder]: [InitializeCommunication] subscribed to /image_metadata for metadata...
[INFO] [h264_video_encoder]: [open_codec] Attempting to open codec: h264_omx
[h264_omx @ 0x18d04b0] libOMX_Core.so not found
[h264_omx @ 0x18d04b0] libOmxCore.so not found
[ERROR] [h264_video_encoder]: [open_codec] Could not open codec
[INFO] [h264_video_encoder]: [open_codec] Attempting to open codec: libx264
[libx264 @ 0x18d1500] using cpu capabilities: ARMv6 NEON
[libx264 @ 0x18d1500] profile High, level 2.1
[libx264 @ 0x18d1500] 264 - core 152 r2854 e9a5903 - H.264/MPEG-4 AVC codec - Copyleft 2003-2017 - http://www.videolan.org/x264.html - options: cabac=1 ref=1 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=2 psy=1 psy_rd=1.00:0.00 mixed_ref=0 me_range=16 chroma_me=1 trellis=0 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=0 threads=4 lookahead_threads=4 sliced_threads=1 slices=4 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=0 weightp=1 keyint=28 keyint_min=15 scenecut=40 intra_refresh=0 rc=abr mbtree=0 bitrate=512 ratetol=1.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
[INFO] [h264_video_encoder]: [Initialize] Encoding using libx264 codec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
